### PR TITLE
Fixed material being confused as same

### DIFF
--- a/source/import_max.py
+++ b/source/import_max.py
@@ -1598,6 +1598,11 @@ def adjust_material(filename, search, obj, mat):
                 matname = mtl_id.children[0].data if mtl_id else get_cls_name(mat)
             else:
                 matname = mtl_name
+            # Make material name unique by appending bitmap name if available
+            # This prevents multiple different materials with the same name from being treated as one
+            texname = material.get('bitmap', None)
+            if texname is not None:
+                matname = f"{matname}_{Path(texname).stem}"
             objMaterial = bpy.data.materials.get(matname)
             if objMaterial is None:
                 objMaterial = bpy.data.materials.new(matname)


### PR DESCRIPTION
I was using this extension on files from here: https://kart2.trondheim.kommune.no/3d_bymodell/ specifically: Trondheim_bymodell_Eksport.max. when i noticed that almost all the buildings had the same textures. The problem was that they all had the same material name, but there images where different. This is an old file from 2016, I dont know if this is a thing that is supposed to happen, but here i have taken the bitmap file and and appended its name on the end of the material name, this means that even if the material names are the same, they become different materials if there bitmap is different.

Maybe this should be extended to include the other maps to like in a hash? Or maybe this is just a fluke that should not happen(only Autodesk knows that). I dont have Autodesk so i cant test more.
